### PR TITLE
Add "types" reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "version": "1.0.0",
   "private": false,
   "main": "dist/index.js",
+  "types": "src/index.d.ts",
   "files": [
     "dist/index.js",
     "src/*.d.ts",


### PR DESCRIPTION
The type declaration tells typescript where to look for the proper types when importing runtime JS code from `dist/index.js`.
It was missing in `package.json` - without it, I couldn't properly import this lib into my TypeScript project.

Read more: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

P.S.: Thanks for the awesome formatter! 👍 